### PR TITLE
Changes for pymeep

### DIFF
--- a/utils/ctlgeom.h
+++ b/utils/ctlgeom.h
@@ -125,6 +125,9 @@ extern void get_grid_size_n(int *nx, int *ny, int *nz);
 GEOMETRIC_OBJECT make_geometric_object(MATERIAL_TYPE material, vector3 center);
 GEOMETRIC_OBJECT make_cylinder(MATERIAL_TYPE material, vector3 center,
 			       number radius, number height, vector3 axis);
+GEOMETRIC_OBJECT make_wedge(MATERIAL_TYPE material, vector3 center,
+                            number radius, number height, vector3 axis,
+                            number wedge_angle, vector3 wedge_start);
 GEOMETRIC_OBJECT make_cone(MATERIAL_TYPE material, vector3 center,
 			   number radius, number height, vector3 axis,
 			   number radius2);

--- a/utils/geom.scm
+++ b/utils/geom.scm
@@ -73,7 +73,6 @@
   (define-derived-property e2 'vector3
     (lambda (object)
       (let ((a (object-property-value object 'axis))
-	    (s (object-property-value object 'start))
 	    (e1 (object-property-value object 'e1)))
 	(vector3-cross a e1)))))
 


### PR DESCRIPTION
* Allow pymeep to call `make_wedge`.
* Remove unused bound variable in wedge class. Neither the class, nor its parents has a `start` property.  I think it was supposed to be `wedge-start` but it isn't used in this function anyway.
@stevengj 