### PR TITLE
Format prism printing like other geometric objects

### DIFF
--- a/utils/geom.c
+++ b/utils/geom.c
@@ -2552,13 +2552,13 @@ void display_prism_info(int indentby, prism *prsm)
   vector3 axis      = prism_vector_p2c(prsm,z0);
   vector3 center    = prism_coordinate_p2c(prsm,vector3_scale(0.5*height,z0));
 
-  printf("%*s     height %g, axis (%g,%g,%g), center (%g,%g,%g), %i vertices:\n", 
-          indentby, "", height,axis.x,axis.y,axis.z,center.x,center.y,center.z,num_vertices);
+  printf("%*s     height %g, axis (%g,%g,%g), %i vertices:\n",
+          indentby, "", height,axis.x,axis.y,axis.z,num_vertices);
   matrix3x3 m_p2c = matrix3x3_inverse(prsm->m_c2p);
   int nv;
   for(nv=0; nv<num_vertices; nv++)
    { vector3 v = matrix3x3_vector3_mult(m_p2c, vertices[nv]);
-     printf("%*s     {%e,%e,%e}\n",indentby,"",v.x,v.y,v.z);
+     printf("%*s     {%g,%g,%g}\n",indentby,"",v.x,v.y,v.z);
    }
 }
 


### PR DESCRIPTION
Ardavan asked for the prism output to be consistent with the other shapes. `center` was being printed twice.
@stevengj @oskooi 