### PR TITLE
Language name in typemap has been deprecated since SWIG 1.3.29

### DIFF
--- a/utils/ctl-io.scm
+++ b/utils/ctl-io.scm
@@ -820,7 +820,7 @@
 ; ***************************************************************************
 
 (define (swig-type-header type-name)
-  (print "%typemap(guile,in) "
+  (print "%typemap(in) "
 	 (if cxx (string-append namespace "::") "")
 	 (c-type-string type-name) " {\n")
   (if cxx (print "using namespace " namespace ";\n"))
@@ -833,7 +833,7 @@
 			     (get-type-descriptor
 			      (list-el-type-name type-name))))))
       (begin
-	(print "%typemap(guile,out) "
+	(print "%typemap(out) "
 	       (if cxx (string-append namespace "::") "")
 	       (c-type-string type-name) " {\n")
 	(if cxx (print "using namespace " namespace ";\n"))

--- a/utils/gen-ctl-io.in
+++ b/utils/gen-ctl-io.in
@@ -202,26 +202,26 @@ EOF
 
 /******* SWIG type-conversion mappings for basic libctl types *******/
 
-%typemap(guile,in) vector3 { \$1 = ctl_convert_vector3_to_c(\$input); }
-%typemap(guile,out) vector3 { \$result = ctl_convert_vector3_to_scm(\$1); }
+%typemap(in) vector3 { \$1 = ctl_convert_vector3_to_c(\$input); }
+%typemap(out) vector3 { \$result = ctl_convert_vector3_to_scm(\$1); }
 
-%typemap(guile,in) matrix3x3 { \$1 = ctl_convert_matrix3x3_to_c(\$input); }
-%typemap(guile,out) matrix3x3 { \$result = ctl_convert_matrix3x3_to_scm(\$1); }
+%typemap(in) matrix3x3 { \$1 = ctl_convert_matrix3x3_to_c(\$input); }
+%typemap(out) matrix3x3 { \$result = ctl_convert_matrix3x3_to_scm(\$1); }
 
-%typemap(guile,in) cvector3 { \$1 = ctl_convert_cvector3_to_c(\$input); }
-%typemap(guile,out) cvector3 { \$result = ctl_convert_cvector3_to_scm(\$1); }
+%typemap(in) cvector3 { \$1 = ctl_convert_cvector3_to_c(\$input); }
+%typemap(out) cvector3 { \$result = ctl_convert_cvector3_to_scm(\$1); }
 
-%typemap(guile,in) cmatrix3x3 { \$1 = ctl_convert_cmatrix3x3_to_c(\$input); }
-%typemap(guile,out) cmatrix3x3 { \$result = ctl_convert_cmatrix3x3_to_scm(\$1); }
+%typemap(in) cmatrix3x3 { \$1 = ctl_convert_cmatrix3x3_to_c(\$input); }
+%typemap(out) cmatrix3x3 { \$result = ctl_convert_cmatrix3x3_to_scm(\$1); }
 
-%typemap(guile,in) cnumber { \$1 = ctl_convert_cnumber_to_c(\$input); }
-%typemap(guile,out) cnumber { \$result = ctl_convert_cnumber_to_scm(\$1); }
+%typemap(in) cnumber { \$1 = ctl_convert_cnumber_to_c(\$input); }
+%typemap(out) cnumber { \$result = ctl_convert_cnumber_to_scm(\$1); }
 
-%typemap(guile,in) function { \$1 = ctl_convert_function_to_c(\$input); }
-%typemap(guile,out) function { \$result = ctl_convert_function_to_scm(\$1); }
+%typemap(in) function { \$1 = ctl_convert_function_to_c(\$input); }
+%typemap(out) function { \$result = ctl_convert_function_to_scm(\$1); }
 
-%typemap(guile,in) object { \$1 = ctl_convert_object_to_c(\$input); }
-%typemap(guile,out) object { \$result = ctl_convert_object_to_scm(\$1); }
+%typemap(in) object { \$1 = ctl_convert_object_to_c(\$input); }
+%typemap(out) object { \$result = ctl_convert_object_to_scm(\$1); }
 
 EOF
 


### PR DESCRIPTION
This cleans up several warnings when building meep.
@stevengj @oskooi 