### PR TITLE
Don't use custom theme for docs

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,1 +1,2 @@
+mkdocs==0.17.5
 python-markdown-math

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,12 +5,9 @@ repo_url: https://github.com/stevengj/libctl/
 docs_dir: 'doc/docs'
 site_dir: 'doc/site'
 
-theme_dir: 'doc/libctl-mkdocs-theme'
-theme: readthedocs
-
-python:
-   version: 2 # for unicode
-   setup_py_install: True
+theme:
+  name: readthedocs
+  # custom_dir: 'doc/libctl-mkdocs-theme'
 
 markdown_extensions:
     - wikilinks


### PR DESCRIPTION
Fixes #30. This is the same issue we had with the Meep docs. The built-in search functionality works now, which was the main benefit of the custom theme.
@stevengj @oskooi 